### PR TITLE
Using kioskboard in embedded webview

### DIFF
--- a/src/kioskboard.js
+++ b/src/kioskboard.js
@@ -760,10 +760,15 @@
               var scrollBehavior = opt.cssAnimations === true ? 'smooth' : 'auto';
               var scrollDelay = opt.cssAnimations === true && typeof opt.cssAnimationsDuration === 'number' ? opt.cssAnimationsDuration : 0;
               var userAgent = navigator.userAgent.toLocaleLowerCase('en');
+              var isEdgeWebView = userAgent.indexOf('edge') > -1 && userAgent.indexOf('webview') > -1;
               var scrollTop = theInputOffsetTop - (isPlacementTop ? keyboardHeight : 0);
-              if (userAgent.indexOf('edge') < 0 && userAgent.indexOf('.net4') < 0) {
+              if ((userAgent.indexOf('edge') < 0 || isEdgeWebView) && userAgent.indexOf('.net4') < 0) {
                 var scrollTimeout = setTimeout(function () {
+                if (isEdgeWebView) {
+                  window.scrollBy(0, theInputOffsetTop);
+                } else {
                   window.scrollTo({ top: scrollTop, left: 0, behavior: scrollBehavior });
+                }
                   clearTimeout(scrollTimeout);
                 }, scrollDelay);
               } else {

--- a/src/kioskboard.js
+++ b/src/kioskboard.js
@@ -761,13 +761,13 @@
               var scrollDelay = opt.cssAnimations === true && typeof opt.cssAnimationsDuration === 'number' ? opt.cssAnimationsDuration : 0;
               var scrollTop = theInputOffsetTop - (isPlacementTop ? keyboardHeight : 0);
               var userAgent = navigator.userAgent.toLocaleLowerCase('en');
-              var isEdgeWebView = userAgent.indexOf('edge') > -1 && userAgent.indexOf('webview') > -1;
               var isBrowserEdgeLegacy = userAgent.indexOf('edge') > -1;
               var isBrowserInternetExplorer = userAgent.indexOf('.net4') > -1;
               var isBrowserEdgeWebView = isBrowserEdgeLegacy && userAgent.indexOf('webview') > -1;
+              
               if ((!isBrowserEdgeLegacy || isBrowserEdgeWebView) && !isBrowserInternetExplorer) {
                 var scrollTimeout = setTimeout(function () {
-                if (isEdgeWebView) {
+                if (isBrowserEdgeWebView) {
                   window.scrollBy(0, theInputOffsetTop);
                 } else {
                   window.scrollTo({ top: scrollTop, left: 0, behavior: scrollBehavior });

--- a/src/kioskboard.js
+++ b/src/kioskboard.js
@@ -759,10 +759,13 @@
             if (autoScroll) {
               var scrollBehavior = opt.cssAnimations === true ? 'smooth' : 'auto';
               var scrollDelay = opt.cssAnimations === true && typeof opt.cssAnimationsDuration === 'number' ? opt.cssAnimationsDuration : 0;
+              var scrollTop = theInputOffsetTop - (isPlacementTop ? keyboardHeight : 0);
               var userAgent = navigator.userAgent.toLocaleLowerCase('en');
               var isEdgeWebView = userAgent.indexOf('edge') > -1 && userAgent.indexOf('webview') > -1;
-              var scrollTop = theInputOffsetTop - (isPlacementTop ? keyboardHeight : 0);
-              if ((userAgent.indexOf('edge') < 0 || isEdgeWebView) && userAgent.indexOf('.net4') < 0) {
+              var isBrowserEdgeLegacy = userAgent.indexOf('edge') > -1;
+              var isBrowserInternetExplorer = userAgent.indexOf('.net4') > -1;
+              var isBrowserEdgeWebView = isBrowserEdgeLegacy && userAgent.indexOf('webview') > -1;
+              if ((!isBrowserEdgeLegacy || isBrowserEdgeWebView) && !isBrowserInternetExplorer) {
                 var scrollTimeout = setTimeout(function () {
                 if (isEdgeWebView) {
                   window.scrollBy(0, theInputOffsetTop);


### PR DESCRIPTION
Using kisokboard in embedded webview doesn't scroll to focus because of different useragent. These changes fix kisokboard autoscroll to focused input also in embedded webview in an UWP (Universal Windows Platform) app.