### PR TITLE
Suggested fix for Autoscroll not happening

### DIFF
--- a/src/kioskboard.js
+++ b/src/kioskboard.js
@@ -749,12 +749,11 @@
 
             // body padding bottom || top: begin
             var isPlacementTop = keyboardPlacement === kioskBoardPlacements.Top;
-            var inputTop = (isPlacementTop ? theInput.getBoundingClientRect().bottom : theInput.getBoundingClientRect().top) || 0;
+            var inputVisibleEdge = (isPlacementTop ? theInput.getBoundingClientRect().top : theInput.getBoundingClientRect().bottom) || 0;
             var docTop = window.document.documentElement.scrollTop || 0;
-            var inputThreshold = isPlacementTop ? (theInput.clientHeight + 20) : 50;
-            var theInputOffsetTop = Math.round(inputTop + docTop) - inputThreshold;
+            var theInputOffsetTop = Math.round(inputVisibleEdge + docTop);
             var isPaddingTop = (theInputOffsetTop < keyboardHeight) && isPlacementTop;
-            var isPaddingBottom = documentHeight <= (theInputOffsetTop + keyboardHeight);
+            var isPaddingBottom = documentHeight <= (theInputOffsetTop + keyboardHeight) && !isPlacementTop;
 
             if (isPaddingTop || isPaddingBottom) {
               var styleElm = window.document.getElementById('KioskboardBodyPadding');
@@ -774,9 +773,12 @@
             // auto scroll: begin
             var autoScroll = opt.autoScroll === true;
             if (autoScroll) {
+              var inputThreshold = isPlacementTop ? 20 : 50;
+              var inputTop = theInput.getBoundingClientRect().top || 0;
+              var inputScrollOffsetTop = Math.round(inputTop + docTop);
               var scrollBehavior = opt.cssAnimations === true ? 'smooth' : 'auto';
               var scrollDelay = opt.cssAnimations === true && typeof opt.cssAnimationsDuration === 'number' ? opt.cssAnimationsDuration : 0;
-              var scrollTop = theInputOffsetTop - (isPlacementTop ? keyboardHeight : 0);
+              var scrollTop = inputScrollOffsetTop - inputThreshold - (isPlacementTop ? keyboardHeight : 0);
 
               var userAgent = window.navigator.userAgent.toLocaleLowerCase('en');
               var isBrowserInternetExplorer = userAgent.indexOf('.net4') > -1;
@@ -786,7 +788,7 @@
               if ((!isBrowserEdgeLegacy || isBrowserEdgeWebView) && !isBrowserInternetExplorer) {
                 var scrollTimeout = setTimeout(function () {
                   if (isBrowserEdgeWebView) {
-                    window.scrollBy(0, theInputOffsetTop);
+                    window.scrollBy(0, inputScrollOffsetTop);
                   } else {
                     window.scrollTo({ top: scrollTop, left: 0, behavior: scrollBehavior });
                   }


### PR DESCRIPTION
As far as I could understand how the autoscroll and the modified section of the code works:
1.) We calculate a padding we add to the body to increase it's innerheight so that the keyboard does not cover anything from the contents.
2.) If autoscroll enabled we scroll to the input.

Why I changed modified the inputTreshold calculation:
The issue described in https://github.com/furcan/KioskBoard/issues/61 was caused by the inputTreshold variable. 
In this scenario:

window size: 1024x768
keyboardsize: 1024x540
theInput.getBoundingClientRect()
DOMRect {x: 239, y: 238, width: 546, height: 54, top: 238, …}

Both isPaddingTop and isPaddingBottom are false. If the inputTreshold variable hadn't decreased the theInputOffsetTop variable's value, the isPaddingBottom would be true.

If I understand the purpose of the inputTreshold variable, it ensures that when the scrolling happens, there is some space left between the keyboard and the input. I suggest to use this variable only when calculating the scroll position, and not when we calculate wether we need body padding or not. 

Why I introduced the new inputVisibleEdge variable:
When deciding wether we need the a body padding we want to ensure that in case of a bottom keyboard the top of the input remains visible, in case of a top keyboard the bottom of the keyboard stays visible. When deciding where to scroll, I'd always want to scroll to the top of the input. 

The original inputTop and theInputOffsetTop variables were initialized so:
var inputTop = (isPlacementTop ? theInput.getBoundingClientRect().bottom : theInput.getBoundingClientRect().top) || 0;
var inputThreshold = isPlacementTop ? (theInput.clientHeight + 20) : 50;
var theInputOffsetTop = Math.round(inputTop + docTop) - inputThreshold;

So in case of a top keyboard the code first set inputTop to the bottom of the input, then decreased this with the height of the input, which is the top of the input. So theInputOffsetTop was the top of the input in both cases increased by 20 or 50. This was ok for the scrolling, but not ok when inspecting wether we need a body padding or not. 

Why I recalculated the boundingClientRect of the input before scrolling:
In case of a top keyboard, when padding top is added to the body the boundingClientRect will change, and has to be recalculated.