### PR TITLE
Add input event parallel to change

### DIFF
--- a/src/kioskboard.js
+++ b/src/kioskboard.js
@@ -575,6 +575,7 @@
             'bubbles': true,
             'cancelable': true,
           });
+          
           // event for input element trigger change: end
 
           // input element keypress listener: begin
@@ -654,6 +655,11 @@
                     // update input value
                     input.value = theInputValArray.join('');
 
+                    //create input event
+                    var inputEvent = new Event('input', {
+                      'bubbles': true,
+                      'data': input.value
+                    });
                     // set next selection index
                     if (input.type !== 'number') {
                       input.setSelectionRange(theInputSelIndex + 1, theInputSelIndex + 1);
@@ -661,6 +667,7 @@
 
                     // input trigger change event for update the value
                     input.dispatchEvent(changeEvent);
+                    input.dispatchEvent(inputEvent);
                   }
                 });
               }

--- a/src/kioskboard.js
+++ b/src/kioskboard.js
@@ -575,7 +575,6 @@
             'bubbles': true,
             'cancelable': true,
           });
-          
           // event for input element trigger change: end
 
           // input element keypress listener: begin


### PR DESCRIPTION
In some situations (e.g. within some React apps) Kioskboard was having an issue with fields clearing themselves out on blur.

Adding a parallel `input` event to the `change` event already firing seems to solve the issue.