### PR TITLE
Add keyboard open callback (/toggle)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -166,6 +166,12 @@ declare namespace KioskBoard {
      * @defaultValue `true`
      */
     keysEnterCanClose?: boolean;
+
+    /**
+     * @property {function} - Optional, The callback function of the virtual keyboard. This function will be called when the input get focused. Return false to prevent keyboard open.
+     * @defaultValue `undefined`
+     */
+    keyboardOpenCallback?: (input: HTMLInputElement | HTMLTextAreaElement) => boolean|void;
   }
 
   /**

--- a/src/kioskboard.js
+++ b/src/kioskboard.js
@@ -68,6 +68,7 @@
     keysEnterText: 'Enter',
     keysEnterCallback: undefined,
     keysEnterCanClose: true,
+    keyboardOpenCallback: undefined,
   };
   var kioskBoardCachedKeys;
   var kioskBoardNewOptions;

--- a/src/kioskboard.js
+++ b/src/kioskboard.js
@@ -358,6 +358,10 @@
 
         // each input focus listener: begin
         var inputFocusListener = function (e) {
+          if (typeof opt.keyboardOpenCallback === 'function' && !opt.keyboardOpenCallback(input)) {
+            return false;
+          }
+
           // input element variables: begin
           var theInput = e.currentTarget;
           var theInputSelIndex = 0;


### PR DESCRIPTION
It can be used as a simple callback or with a toggle to temporary disable KioskBoard (eg. using a toggle to disable it on devices with a physical keyboard).